### PR TITLE
Updated deploy.yaml to apps/v1

### DIFF
--- a/manifests/deploy.yaml
+++ b/manifests/deploy.yaml
@@ -13,12 +13,15 @@
 #   limitations under the License.
 
 #Deploy the pod
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: portfolio
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: portfolio
   template:
     metadata:
       annotations:


### PR DESCRIPTION
extensions/v1beta1 is deprecated and this manifest will fail on any Kubernetes > 1.15.